### PR TITLE
Fix icaltime from ints bug

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -312,4 +312,22 @@ mod tests {
         let time = IcalTime::floating_ymd(2000, 12, 32);
         assert_eq!("20010101", time.to_string());
     }
+
+    #[test]
+    fn test_invalid_hour() {
+        let time = IcalTime::floating_ymd(2000, 12, 31).and_hms(25, 0, 0);
+        assert_eq!("20010101T010000", time.to_string());
+    }
+
+    #[test]
+    fn test_invalid_minute() {
+        let time = IcalTime::floating_ymd(2000, 12, 31).and_hms(24, 61, 0);
+        assert_eq!("20010101T010100", time.to_string());
+    }
+
+    #[test]
+    fn test_invalid_second() {
+        let time = IcalTime::floating_ymd(2000, 12, 31).and_hms(24, 60, 61);
+        assert_eq!("20010101T010101", time.to_string());
+    }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -299,4 +299,16 @@ mod tests {
         let time = IcalTime::utc();
         assert_eq!("20130102T010203Z", time.succ().to_string());
     }
+
+    #[test]
+    fn test_invalid_month() {
+        let time = IcalTime::floating_ymd(2000, 13, 1);
+        assert_eq!("20010101", time.to_string());
+    }
+
+    #[test]
+    fn test_invalid_day() {
+        let time = IcalTime::floating_ymd(2000, 12, 32);
+        assert_eq!("20010101", time.to_string());
+    }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -46,6 +46,8 @@ impl IcalTime {
         time.second = second;
         time.is_date = 0;
 
+        let time = unsafe { ical::icaltime_normalize(time) };
+
         IcalTime { time }
     }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -35,6 +35,7 @@ impl IcalTime {
             is_daylight: 0,
             zone: ::std::ptr::null(),
         };
+        let time = unsafe { ical::icaltime_normalize(time) };
         IcalTime { time }
     }
 


### PR DESCRIPTION
This patchset fixes a bug where the `IcalTime` object was not normalized when instantiating.

---

@Valodim and @sonea-pm8 you might want to have a look for khaleesii.